### PR TITLE
fix GitHub edit url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,8 @@ site_description: Documentation for the users of Mat3ra materials modeling platf
 dev_addr: "localhost:8000"
 
 repo_name: 'exabyte-io/documentation'
-repo_url: 'https://github.com/exabyte-io/exabyte-public-documentation'
+repo_url: 'https://github.com/exabyte-io/documentation'
+edit_uri: 'edit/master/lang/en/docs/'
 extra_css:
     - https://cdnjs.cloudflare.com/ajax/libs/material-design-iconic-font/2.2.0/css/material-design-iconic-font.min.css
     - extra/css/general.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ extra_javascript:
     - 'https://www.googletagmanager.com/gtag/js?id=UA-69270713-5'
     - extra/js/url_parameters.js
 
-copyright: © 2022 <a target="_blank" href="https://mat3ra.com">Exabyte Inc</a>. All rights reserved. | <a target="_blank" href="https://platform.mat3ra.com">Back to platform</a>
+copyright: © 2023 <a target="_blank" href="https://mat3ra.com">Exabyte Inc</a>. All rights reserved. | <a target="_blank" href="https://platform.mat3ra.com">Back to platform</a>
 
 extra:
     version: "2022.5.19"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,7 @@ extra_javascript:
 copyright: © 2023 <a target="_blank" href="https://mat3ra.com">Exabyte Inc</a>. All rights reserved. | <a target="_blank" href="https://platform.mat3ra.com">Back to platform</a>
 
 extra:
-    version: "2022.5.19"
+    version: "2023.4.13"
     preload_javascript:
         - /extra/js/preload_hotjar.js
         - /extra/js/preload.js


### PR DESCRIPTION
<img width="546" alt="Screenshot 2023-04-08 at 2 07 11 PM" src="https://user-images.githubusercontent.com/31024886/230706466-cebafdce-1fea-4413-8568-d4129519117d.png">

As the documentation folder structure of this project is not the same as mkdocs defaults, current edit url is broken. I have set the `edit_uri` as described [here](https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository#code-actions).

@timurbazhirov you might want to update the doc site link on the repo description as well.

<img width="453" alt="Screenshot 2023-04-08 at 2 13 37 PM" src="https://user-images.githubusercontent.com/31024886/230706602-3ead94de-3f94-4691-84fe-91710e1dc67e.png">

Edit: I have also updated the copyright year. You may squash and merge if you do not want multiple micro commits. 

<img width="488" alt="Screenshot 2023-04-08 at 6 05 20 PM" src="https://user-images.githubusercontent.com/31024886/230715613-af6a0562-7034-4a3d-ad23-1363eaa063d6.png">