### PR TITLE
connect netlify to generate deploy previews

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  command = "bash ./scripts/setup-ubuntu.sh && mkdocs build"
+  publish = "site/"
+
+[build.environment]
+  PYTHON_VERSION = "3.8"
+  NODE_VERSION = "18"


### PR DESCRIPTION
In order to connect Netlify requires following one-time setup:

- Create a new site and select **Import an existing project**

<img width="362" alt="Screenshot 2023-05-06 at 12 50 04 PM" src="https://user-images.githubusercontent.com/31024886/236600848-e056b4d1-42b5-44a9-a4a1-7b98bf25ba6f.png">

- In the next step select GitHub and authorise
- You may only allow Netlify to access the **documentation** repo
- Once done, you should see the **documentation** repo in Netlify
- Rest should be automatic, all build settings are provided via `netlify.toml` included in this PR.