### PR TITLE
DOC: add a reference to rendered notebooks in the REST API documentation

### DIFF
--- a/lang/en/docs/rest-api/api-examples.md
+++ b/lang/en/docs/rest-api/api-examples.md
@@ -1,6 +1,8 @@
 # API Examples
 
-We published an open-source repository[^1] with examples for performing some of the most common tasks in the Exabyte.io platform through the API in Jupyter Notebook format. Readers are referred to the original online link below for more information.
+We published an open-source repository[^1] with examples for performing some of the most common tasks in the Mat3ra.com platform through the API in Jupyter Notebook format. Readers are referred to the original online link below for more information.
+
+Rendered notebooks are available [here](./rendered-notebooks/).
 
 ## Links
 


### PR DESCRIPTION
This update is needed for publishing the rendered API example notebooks (see https://github.com/Exabyte-io/api-examples/pull/82).