### PR TITLE
SOF-7176: add netlify custom build script

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "bash ./scripts/setup-ubuntu.sh && mkdocs build"
+  command = "bash ./scripts/netlify-build.sh"
   publish = "site/"
 
 [build.environment]

--- a/scripts/netlify-build.sh
+++ b/scripts/netlify-build.sh
@@ -1,0 +1,10 @@
+git submodule update --recursive --init
+git lfs install
+git lfs pull
+# git LFS objects can alternatively be handled via environmental variables
+# GIT_LFS_ENABLED=true and GIT_LFS_FETCH_INCLUDE
+# https://answers.netlify.com/t/problem-checking-out-file-stored-in-git-lfs-on-github/103897/7
+
+# pip packages are automatically installed by netlify
+# if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+mkdocs build


### PR DESCRIPTION
Previously we were using ubuntu setup script, however ubuntu apt command is now allowed on netlify runner.