### PR TITLE
chore: update GitHub org references from Exabyte-io to mat3ra

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Checkout actions repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: Exabyte-io/actions
+          repository: mat3ra/actions
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
           path: actions
 

--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: "3.10"
 
       - name: Build pages (legacy)
-        uses: Exabyte-io/action-mkdocs-build@main
+        uses: mat3ra/action-mkdocs-build@main
 
       - name: Build split sites
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "esse"]
 	path = data/esse
-	url = https://github.com/Exabyte-io/esse.git
+	url = https://github.com/mat3ra/esse.git

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For a quick installation:
 2. Clone this repository:
 
     ```bash
-    git clone https://github.com/Exabyte-io/documentation.git
+    git clone https://github.com/mat3ra/documentation.git
     ```
 
 3. Setup virtual environment
@@ -457,7 +457,7 @@ Including a clickable image map is done as follows. Note that absolute paths to 
 
 Including resolved JSON schemas and associated examples should be done within dedicated `data.md` pages for each concept being explained.
 
-The [markdown_include](https://github.com/Exabyte-io/markdown-include) package is used to include JSON content into markdown documents, by putting direct links to pages inside the [ESSE repository](https://github.com/Exabyte-io/exabyte-esse) instead of copying their contents in the main documentation.
+The [markdown_include](https://github.com/mat3ra/markdown-include) package is used to include JSON content into markdown documents, by putting direct links to pages inside the [ESSE repository](https://github.com/mat3ra/exabyte-esse) instead of copying their contents in the main documentation.
 
 ```text
     === "Schema"

--- a/data/example-json/machine-learning-predict.json
+++ b/data/example-json/machine-learning-predict.json
@@ -8,7 +8,7 @@
     },
     "owner": {
         "_id": "5b143a4ecd313f405b314224",
-        "slug": "exabyte-io",
+        "slug": "mat3ra",
         "cls": "Account"
     },
     "schemaVersion": "0.2.0",
@@ -219,7 +219,7 @@
                                 "CONTAINER": "production-20160630-cluster-001",
                                 "PROVIDER": "aws",
                                 "REGION": "us-east-1",
-                                "NAME": "/cluster-001-share/groups/exabyte-io/exabyte-io-2021-ml-work/checking-ml-file-property-ec8ToqKwpWDGiyNCS/.job_context/target.pkl"
+                                "NAME": "/cluster-001-share/groups/mat3ra/mat3ra-2021-ml-work/checking-ml-file-property-ec8ToqKwpWDGiyNCS/.job_context/target.pkl"
                             }
                         },
                         {
@@ -230,7 +230,7 @@
                                 "CONTAINER": "production-20160630-cluster-001",
                                 "PROVIDER": "aws",
                                 "REGION": "us-east-1",
-                                "NAME": "/cluster-001-share/groups/exabyte-io/exabyte-io-2021-ml-work/checking-ml-file-property-ec8ToqKwpWDGiyNCS/.job_context/workflow_context_file_mapping"
+                                "NAME": "/cluster-001-share/groups/mat3ra/mat3ra-2021-ml-work/checking-ml-file-property-ec8ToqKwpWDGiyNCS/.job_context/workflow_context_file_mapping"
                             }
                         },
                         {
@@ -241,7 +241,7 @@
                                 "CONTAINER": "production-20160630-cluster-001",
                                 "PROVIDER": "aws",
                                 "REGION": "us-east-1",
-                                "NAME": "/cluster-001-share/groups/exabyte-io/exabyte-io-2021-ml-work/checking-ml-file-property-ec8ToqKwpWDGiyNCS/.job_context/descriptors.pkl"
+                                "NAME": "/cluster-001-share/groups/mat3ra/mat3ra-2021-ml-work/checking-ml-file-property-ec8ToqKwpWDGiyNCS/.job_context/descriptors.pkl"
                             }
                         },
                         {
@@ -252,7 +252,7 @@
                                 "CONTAINER": "production-20160630-cluster-001",
                                 "PROVIDER": "aws",
                                 "REGION": "us-east-1",
-                                "NAME": "/cluster-001-share/groups/exabyte-io/exabyte-io-2021-ml-work/checking-ml-file-property-ec8ToqKwpWDGiyNCS/.job_context/target_scaler.pkl"
+                                "NAME": "/cluster-001-share/groups/mat3ra/mat3ra-2021-ml-work/checking-ml-file-property-ec8ToqKwpWDGiyNCS/.job_context/target_scaler.pkl"
                             }
                         },
                         {
@@ -263,7 +263,7 @@
                                 "CONTAINER": "production-20160630-cluster-001",
                                 "PROVIDER": "aws",
                                 "REGION": "us-east-1",
-                                "NAME": "/cluster-001-share/groups/exabyte-io/exabyte-io-2021-ml-work/checking-ml-file-property-ec8ToqKwpWDGiyNCS/.job_context/descriptor_scaler.pkl"
+                                "NAME": "/cluster-001-share/groups/mat3ra/mat3ra-2021-ml-work/checking-ml-file-property-ec8ToqKwpWDGiyNCS/.job_context/descriptor_scaler.pkl"
                             }
                         },
                         {
@@ -274,7 +274,7 @@
                                 "CONTAINER": "production-20160630-cluster-001",
                                 "PROVIDER": "aws",
                                 "REGION": "us-east-1",
-                                "NAME": "/cluster-001-share/groups/exabyte-io/exabyte-io-2021-ml-work/checking-ml-file-property-ec8ToqKwpWDGiyNCS/.job_context/sklearn_mlp.pkl"
+                                "NAME": "/cluster-001-share/groups/mat3ra/mat3ra-2021-ml-work/checking-ml-file-property-ec8ToqKwpWDGiyNCS/.job_context/sklearn_mlp.pkl"
                             }
                         },
                         {
@@ -285,7 +285,7 @@
                                 "CONTAINER": "production-20160630-cluster-001",
                                 "PROVIDER": "aws",
                                 "REGION": "us-east-1",
-                                "NAME": "/cluster-001-share/groups/exabyte-io/exabyte-io-2021-ml-work/checking-ml-file-property-ec8ToqKwpWDGiyNCS/.job_context/predictions.pkl"
+                                "NAME": "/cluster-001-share/groups/mat3ra/mat3ra-2021-ml-work/checking-ml-file-property-ec8ToqKwpWDGiyNCS/.job_context/predictions.pkl"
                             }
                         },
                         {
@@ -296,7 +296,7 @@
                                 "CONTAINER": "production-20160630-cluster-001",
                                 "PROVIDER": "aws",
                                 "REGION": "us-east-1",
-                                "NAME": "/cluster-001-share/groups/exabyte-io/exabyte-io-2021-ml-work/checking-ml-file-property-ec8ToqKwpWDGiyNCS/.job_context/RMSE.pkl"
+                                "NAME": "/cluster-001-share/groups/mat3ra/mat3ra-2021-ml-work/checking-ml-file-property-ec8ToqKwpWDGiyNCS/.job_context/RMSE.pkl"
                             }
                         }
                     ],

--- a/data/example-json/machine-learning-train.json
+++ b/data/example-json/machine-learning-train.json
@@ -714,7 +714,7 @@
     "hash": "c0c97c1dffb00371a5aec012306d9b4b",
     "owner": {
         "_id": "5b143a4ecd313f405b314224",
-        "slug": "exabyte-io",
+        "slug": "mat3ra",
         "cls": "Account"
     },
     "creator": {

--- a/lang/en/docs/cli/actions/add-software.md
+++ b/lang/en/docs/cli/actions/add-software.md
@@ -239,7 +239,7 @@ apptainer exec --nv --bind /export,/cluster-001-share <path-to-image.sif> pw.x -
 To understand the details about library paths, one may inspect modulefiles (e.g.,
 `/cluster-001-share/compute/modulefiles/applications/espresso/7.5-cuda-12.8`)
 available in our clusters and [job scripts](
-https://github.com/Exabyte-io/cli-job-examples/blob/main/espresso/gpu/job.gpu.pbs)
+https://github.com/mat3ra/cli-job-examples/blob/main/espresso/gpu/job.gpu.pbs)
 to see how it is implemented. Do not forget to use a GPU-enabled queue,
 such as [GOF]({{ resources_url }}/infrastructure/clusters/google/) to submit your GPU jobs.
 
@@ -281,7 +281,7 @@ Once the job is completed, all output files will be saved under the directory
 from which the job was submitted. Please follow [this documentation page](
 ../../jobs-cli/batch-scripts/apptainer.md) to find more about Apptainer
 integration. For practical templates, please visit[CLI job examples](
-https://github.com/Exabyte-io/cli-job-examples).
+https://github.com/mat3ra/cli-job-examples).
 
 
 ## Transfer external images

--- a/lang/en/docs/data-structured/convention.md
+++ b/lang/en/docs/data-structured/convention.md
@@ -1,6 +1,6 @@
 # ESSE Data Convention
 
-Our approach towards storing and organizing structured data is based on the **ESSE Data Convention (EDC)** explained in the present documentation. ESSE stands for Essential Source of Schemas and Examples. The corresponding schema implementations are open-source and available in the [GitHub repository](https://github.com/Exabyte-io/esse) and as a package on [PyPI](https://pypi.org/project/mat3ra-esse/).
+Our approach towards storing and organizing structured data is based on the **ESSE Data Convention (EDC)** explained in the present documentation. ESSE stands for Essential Source of Schemas and Examples. The corresponding schema implementations are open-source and available in the [GitHub repository](https://github.com/mat3ra/esse) and as a package on [PyPI](https://pypi.org/project/mat3ra-esse/).
 
 We use this convention to store and organize the information associated with the [Entities]({{ reference_url }}/entities-general/overview/) present across our platform, and their corresponding [Accounts]({{ reference_url }}/accounts/overview/) and [Permissions]({{ reference_url }}/entities-general/permissions/). The convention is designed with the aim of facilitating both the access and collaboration with regards to such entities. The fundamental practices are further elucidated in the sections below.
 

--- a/lang/en/docs/getting-started/content-highlights.md
+++ b/lang/en/docs/getting-started/content-highlights.md
@@ -98,15 +98,15 @@ JavaScript packages are available on [npm](https://www.npmjs.com/search?q=%40mat
 
 ### 6.2. Open-Source Repositories
 
-- [Exabyte-io GitHub organization](https://github.com/Exabyte-io/){:target='_blank'} — data structures for materials, workflows, and properties
-- [Materials Designer](https://github.com/Exabyte-io/materials-designer){:target='_blank'} — JavaScript library for web-based materials design
-- [API examples](https://github.com/Exabyte-io/api-examples){:target='_blank'} — Jupyter notebooks demonstrating REST API usage
+- [Mat3ra GitHub organization](https://github.com/mat3ra/){:target='_blank'} — data structures for materials, workflows, and properties
+- [Materials Designer](https://github.com/mat3ra/materials-designer){:target='_blank'} — JavaScript library for web-based materials design
+- [API examples](https://github.com/mat3ra/api-examples){:target='_blank'} — Jupyter notebooks demonstrating REST API usage
 
 ### 6.3. Programmatic Access (REST API)
 
-- [Upload materials](https://github.com/Exabyte-io/api-examples/blob/main/examples/material/create_material.ipynb){:target='_blank'}
-- [Run simulations and extract properties as JSON](https://github.com/Exabyte-io/api-examples/blob/main/examples/job/run-simulations-and-extract-properties.ipynb){:target='_blank'}
-- [All API examples (GitHub)](https://github.com/Exabyte-io/api-examples){:target='_blank'}
+- [Upload materials](https://github.com/mat3ra/api-examples/blob/main/examples/material/create_material.ipynb){:target='_blank'}
+- [Run simulations and extract properties as JSON](https://github.com/mat3ra/api-examples/blob/main/examples/job/run-simulations-and-extract-properties.ipynb){:target='_blank'}
+- [All API examples (GitHub)](https://github.com/mat3ra/api-examples){:target='_blank'}
 
 
 ## 7. Learning Resources

--- a/lang/en/docs/index-guide.md
+++ b/lang/en/docs/index-guide.md
@@ -165,7 +165,7 @@ Platform access, notebook environments, and software management.
 
 <!--
 TODOs:
-- add noteebooks from https://github.com/Exabyte-io/api-examples/tree/main/other/materials_designer
+- add noteebooks from https://github.com/mat3ra/api-examples/tree/main/other/materials_designer
 - add notebooks for workflows from api-examples
 - add mention of "experiments" from api-examples
 -->

--- a/lang/en/docs/infrastructure/clusters/directories.md
+++ b/lang/en/docs/infrastructure/clusters/directories.md
@@ -6,7 +6,7 @@ The following directories are present under the home folder of each cluster (ref
 .
 ├── data
 ├── dropbox              => /dropbox/gmogni
-├── exabyte-io           => /cluster-001-share/groups/exabyte-io
+├── mat3ra           => /cluster-001-share/groups/mat3ra
 └── job_script_templates => /export/compute/job_script_templates
 ```
 
@@ -33,9 +33,9 @@ The "dropbox" and "job_script_templates" folders are present under both Cluster 
     
 ## Shared Folders for Organizations
 
-Simulations data for [Organizations]({{ reference_url }}/collaboration/organizations/overview/) (collaborative [accounts]({{ reference_url }}/accounts/overview/)) is stored in a dedicated **shared folder** accessible by its **members only**. This shared folder bears the same name as the Organization itself: for example, "exabyte-io" in the visual above.  Simulation files present under this data are organized according to the Project/Job based directory naming explained below.
+Simulations data for [Organizations]({{ reference_url }}/collaboration/organizations/overview/) (collaborative [accounts]({{ reference_url }}/accounts/overview/)) is stored in a dedicated **shared folder** accessible by its **members only**. This shared folder bears the same name as the Organization itself: for example, "mat3ra" in the visual above.  Simulation files present under this data are organized according to the Project/Job based directory naming explained below.
 
-Each organization of which the user is member has its own corresponding shared directory. For example, organization `exabyte-io` has its folder under the path `/share/groups/exabyte-io/`.
+Each organization of which the user is member has its own corresponding shared directory. For example, organization `mat3ra` has its folder under the path `/share/groups/mat3ra/`.
 
 ## Temporary Data
  

--- a/lang/en/docs/jupyterlite/accessing-jupyterlite.md
+++ b/lang/en/docs/jupyterlite/accessing-jupyterlite.md
@@ -21,7 +21,7 @@ To access JupyterLite directly, navigate to the following URL:
 https://jupyterlite.mat3ra.com/lab/index.html
 ```
 
-To access the Introduction notebook summarizing the functionality available in [mat3ra-made](https://github.com/Exabyte-io/made):
+To access the Introduction notebook summarizing the functionality available in [mat3ra-made](https://github.com/mat3ra/made):
 
 ```
 https://jupyterlite.mat3ra.com/lab/tree?path=made/Introduction.ipynb

--- a/lang/en/docs/jupyterlite/dependencies-installation.md
+++ b/lang/en/docs/jupyterlite/dependencies-installation.md
@@ -21,7 +21,7 @@ from utils.jupyterlite import get_materials
 ## Listing notebook dependencies in `config.yaml`
 
 Some of the necessary packages are compiled into pure Python wheels and provided inside the `mat3ra-api-examples` package. In top-level `packages` folder.
-The dependencies for each notebook and default ones are listed in the [`config.yml` file]("https://github.com/Exabyte-io/api-examples/blob/5e0109589da981b60fec1c1cfcae1977abbbd8ec/config.yml") on the top-level.
+The dependencies for each notebook and default ones are listed in the [`config.yml` file]("https://github.com/mat3ra/api-examples/blob/5e0109589da981b60fec1c1cfcae1977abbbd8ec/config.yml") on the top-level.
 
 To install packages required for the notebook, one can use `install_packages` function from `utils.jupyterlite` module and provide the name of the notebook and the relative path to the `config.yml` file:
 

--- a/lang/en/docs/materials-designer/header-menu/input-output/standata-import.md
+++ b/lang/en/docs/materials-designer/header-menu/input-output/standata-import.md
@@ -23,4 +23,4 @@ Materials (Graphene and Ni in this case) should now be available in the material
 
 ## Links
 
-1. Standata repository on <a href="https://github.com/Exabyte-io/standata" target="_blank">GitHub</a>. 
+1. Standata repository on <a href="https://github.com/mat3ra/standata" target="_blank">GitHub</a>. 

--- a/lang/en/docs/materials/actions/set-default.md
+++ b/lang/en/docs/materials/actions/set-default.md
@@ -4,4 +4,4 @@ The initial default material for a new Exabyte account is set to FCC Silicon [^1
 
 ## Links
 
-[^1]: [Example Si FCC material, Exabyte Platform Website](https://platform.mat3ra.com/exabyte-io/materials/cMK8Z5hZMo23iDb9Z)
+[^1]: [Example Si FCC material, Exabyte Platform Website](https://platform.mat3ra.com/mat3ra/materials/cMK8Z5hZMo23iDb9Z)

--- a/lang/en/docs/metadata/general.json
+++ b/lang/en/docs/metadata/general.json
@@ -3,7 +3,7 @@
         "chemistry",
         "cloud computing",
         "exabyte",
-        "exabyte-io",
+        "mat3ra",
         "high-performance computing",
         "HPC",
         "industry",

--- a/lang/en/docs/properties-directory/non-scalar/workflow.md
+++ b/lang/en/docs/properties-directory/non-scalar/workflow.md
@@ -8,7 +8,7 @@ workflow being generated and placed in the user's account.
 ## Creation during ML Jobs
 
 If any unit in the workflow has the `workflow:pyml_predict` property,
-[Express will be called](https://github.com/Exabyte-io/express/blob/dev/express/properties/workflow.py) to construct
+[Express will be called](https://github.com/mat3ra/express/blob/dev/express/properties/workflow.py) to construct
 the new predict workflow. The following process is performed to convert a workflow from "Train" to "Predict" mode:
 
 - The `IS_WORKFLOW_RUNNING_TO_PREDICT` flag is set to `True`

--- a/lang/en/docs/properties/data/periodic-table.md
+++ b/lang/en/docs/properties/data/periodic-table.md
@@ -6,4 +6,4 @@ We assembled the data using the open-source Ref. [^1] below.
 
 ## Links
 
-[^1]: [Exabyte.io Periodic Table Data, JSON, Github Repository](https://github.com/Exabyte-io/periodic-table)
+[^1]: [Exabyte.io Periodic Table Data, JSON, Github Repository](https://github.com/mat3ra/periodic-table)

--- a/lang/en/docs/rest-api/api-client.md
+++ b/lang/en/docs/rest-api/api-client.md
@@ -2,7 +2,7 @@
 
 ## Python
 
-We have deployed a python-based [**API client**](https://github.com/Exabyte-io/exabyte-api-client)[^1] providing access to the RESTful-API endpoints. Readers are referred to the source code repository linked below for more information.
+We have deployed a python-based [**API client**](https://github.com/mat3ra/api-client)[^1] providing access to the RESTful-API endpoints. Readers are referred to the source code repository linked below for more information.
 
 ## Other
 
@@ -10,6 +10,6 @@ Please [contact us]({{ interface_url }}/ui/support/) if you are interested in an
 
 ## Links
 
-[^1]: [Exabyte API Client repository, Github](https://github.com/Exabyte-io/exabyte-api-client)
+[^1]: [Mat3ra API Client repository, Github](https://github.com/mat3ra/api-client)
 
 ///FOOTNOTES GO HERE///

--- a/lang/en/docs/rest-api/api-examples.md
+++ b/lang/en/docs/rest-api/api-examples.md
@@ -2,10 +2,10 @@
 
 We published an open-source repository[^1] with examples for performing some of the most common tasks in the Mat3ra.com platform through the API in Jupyter Notebook format. Readers are referred to the original online link below for more information.
 
-Rendered notebooks are available in the [API Examples repository](https://github.com/Exabyte-io/exabyte-api-examples).
+Rendered notebooks are available in the [API Examples repository](https://github.com/mat3ra/api-examples).
 
 ## Links
 
-[^1]: [Exabyte API Examples repository, GitHub](https://github.com/Exabyte-io/exabyte-api-examples)
+[^1]: [Mat3ra API Examples repository, GitHub](https://github.com/mat3ra/api-examples)
 
 ///FOOTNOTES GO HERE///

--- a/lang/en/docs/software-directory/scripting/jupyter-lab/data.md
+++ b/lang/en/docs/software-directory/scripting/jupyter-lab/data.md
@@ -18,8 +18,8 @@ We present in what follows the [structured representation]({{ data_url }}/data-s
 
 1. Initially, the root of the Dropbox folder is passed to the application on the start, so the files at the root of the [Dropbox]({{ resources_url }}/data-in-objectstorage/dropbox/) directory can be accessed
 2. Upon each "Save and Checkpoint" action invoked inside the notebook, the ipynb file is overwritten. A new version is stored in the file system, and a checkpoint is saved to the job inside its directory both in the [command-line]({{ cli_url }}/jobs-cli/batch-scripts/directories/#working-directory) and on the [web interface]({{ resources_url }}/data-in-objectstorage/files/).
-3. All notebooks have access to the filesystem accessible to the user on the corresponding computational node, namely the [home]({{ resources_url }}/infrastructure/clusters/directories/) and [share]({{ resources_url }}/infrastructure/clusters/directories/) directories. For example, the following command will list the shared directory for the account "exabyte-io", when invoked inside the Jupyter Notebook running on "cluster-007":
+3. All notebooks have access to the filesystem accessible to the user on the corresponding computational node, namely the [home]({{ resources_url }}/infrastructure/clusters/directories/) and [share]({{ resources_url }}/infrastructure/clusters/directories/) directories. For example, the following command will list the shared directory for the account "mat3ra", when invoked inside the Jupyter Notebook running on "cluster-007":
 
     ```bash
-    ls -lhta /cluster-007-share/groups/exabyte-io
+    ls -lhta /cluster-007-share/groups/mat3ra
     ```

--- a/lang/en/docs/tutorials/contribute-new-application.md
+++ b/lang/en/docs/tutorials/contribute-new-application.md
@@ -5,14 +5,14 @@
 
     1. **Build the Image:** Package your application into an Apptainer
     container. Create a PR to the [application-containers-public](
-    https://github.com/Exabyte-io/application-containers-public) repository
+    https://github.com/mat3ra/application-containers-public) repository
     with the Apptainer `.def` file and register it in `manifest.yml`. Merge this
     PR first so the container image is built and published to the GitHub
     Container Registry (GHCR).
 
     2. **Update the Metadata:** Add the application's YAML metadata, templates,
     and executables, ensuring your image tag matches Step 1 exactly. Create a PR
-    to the [standata](https://github.com/Exabyte-io/standata) repository. Once
+    to the [standata](https://github.com/mat3ra/standata) repository. Once
     merged and deployed, the application will be available on both the
     web-interface and the CLI.
 
@@ -40,12 +40,12 @@ Contributing a new application involves creating Pull Requests (PRs) to two
 repositories:
 
 [**application-containers-public**](
-https://github.com/Exabyte-io/application-containers-public) holds the Apptainer
+https://github.com/mat3ra/application-containers-public) holds the Apptainer
 definition files and a `manifest.yml` that drives a GitHub Actions (GHA)
 workflow. On merge, GHA builds each image and pushes it to the GitHub Container
 Registry (GHCR).
 
-[**standata**](https://github.com/Exabyte-io/standata) holds the platform
+[**standata**](https://github.com/mat3ra/standata) holds the platform
 metadata, including application name, version, build flavor, the GHCR image tag
 to pull, and the runtime environment variables. The platform reads this
 repository to populate the application dropdown in the web-interface. Necessary
@@ -84,8 +84,8 @@ flowchart TB
 
 ### 2.1. Fork and clone the repository
 
-First, fork [github.com/Exabyte-io/application-containers-public](
-https://github.com/Exabyte-io/application-containers-public) on GitHub, then
+First, fork [github.com/mat3ra/application-containers-public](
+https://github.com/mat3ra/application-containers-public) on GitHub, then
 clone the fork locally. The top-level layout is:
 
 ```
@@ -113,7 +113,7 @@ possible:
 
 ```singularity
 Bootstrap: oras
-From: ghcr.io/exabyte-io/application-containers-public/almalinux-apptainer-gnu:9.7-2
+From: ghcr.io/mat3ra/application-containers-public/almalinux-apptainer-gnu:9.7-2
 ```
 
 This reuses tested toolchains and keeps build times short.
@@ -174,14 +174,14 @@ checks whether each tag already exists in GHCR, and if not, runs
 After merge, the image is available at:
 
 ```bash
-apptainer pull oras://ghcr.io/exabyte-io/application-containers-public/espresso:7.5-gnu-1
+apptainer pull oras://ghcr.io/mat3ra/application-containers-public/espresso:7.5-gnu-1
 ```
 
 The image name, and tag are needed in the next section.
 
 ### 2.5. Example Pull Requests
-- [GNU build of Quantum ESPRESSO 7.5](https://github.com/Exabyte-io/application-containers-public/pull/7/changes)
-- [Intel build of LAMMPS](https://github.com/Exabyte-io/application-containers-public/pull/9/changes)
+- [GNU build of Quantum ESPRESSO 7.5](https://github.com/mat3ra/application-containers-public/pull/7/changes)
+- [Intel build of LAMMPS](https://github.com/mat3ra/application-containers-public/pull/9/changes)
 
 
 ## 3. `standata` repository
@@ -195,7 +195,7 @@ The image name, and tag are needed in the next section.
 
 ### 3.1. Fork and clone the repository
 
-Fork [github.com/Exabyte-io/standata](https://github.com/Exabyte-io/standata)
+Fork [github.com/mat3ra/standata](https://github.com/mat3ra/standata)
 and clone locally. The relevant subtree is:
 
 ```
@@ -372,8 +372,8 @@ has been merged and the image is live in GHCR. Commit the generated files under
 `data/` and `dist/` produced by the build step above.
 
 ### 3.8. Example Pull Requests
-- [Quantum ESPRESSO 7.5](https://github.com/Exabyte-io/standata/pull/109/changes)
-- [LAMMPS](https://github.com/Exabyte-io/standata/pull/91/changes)
+- [Quantum ESPRESSO 7.5](https://github.com/mat3ra/standata/pull/109/changes)
+- [LAMMPS](https://github.com/mat3ra/standata/pull/91/changes)
 
 One may ignore the auto-generated files under `data/`, `dist/`, and `src/`
 directories while reviewing the PR changes.
@@ -413,6 +413,6 @@ application is also available via modulefile for CLI use.
 ## 5. References
 
 - Apptainer Definition and container building: [Adding New Software](/cli/actions/add-software)
-- Container repository: [github.com/Exabyte-io/application-containers-public](https://github.com/Exabyte-io/application-containers-public)
-- Metadata repository: [github.com/Exabyte-io/standata](https://github.com/Exabyte-io/standata)
-- Published images: [Exabyte-io packages on GHCR](https://github.com/orgs/Exabyte-io/packages?repo_name=application-containers-public)
+- Container repository: [github.com/mat3ra/application-containers-public](https://github.com/mat3ra/application-containers-public)
+- Metadata repository: [github.com/mat3ra/standata](https://github.com/mat3ra/standata)
+- Published images: [Mat3ra packages on GHCR](https://github.com/orgs/mat3ra/packages?repo_name=application-containers-public)

--- a/lang/en/docs/tutorials/dft/electronic/valence-band-offset.md
+++ b/lang/en/docs/tutorials/dft/electronic/valence-band-offset.md
@@ -42,9 +42,9 @@ Three materials are required, corresponding to the MoS<sub>2</sub>/WS<sub>2</sub
 
 The initial interface structure was taken from [materialsproject.org](https://materialsproject.org/materials/mp-1023954) and optimized via variable-cell relaxation of the x- and y-components. The monolayer structures were extracted from the interface and optimized in the same way. The final structures are available on the Mat3ra platform:
 
-- [MoS2/WS2 heterostructure](https://platform.mat3ra.com/exabyte-io/materials/cxgeoQwPJQJbgA2aD)
-- [WS<sub>2</sub> monolayer](https://platform.mat3ra.com/exabyte-io/materials/5JcsfbBPKFWjxGXkX)
-- [MoS<sub>2</sub> monolayer](https://platform.mat3ra.com/exabyte-io/materials/Cyr7Y6sefZsmZo6bH)
+- [MoS2/WS2 heterostructure](https://platform.mat3ra.com/mat3ra/materials/cxgeoQwPJQJbgA2aD)
+- [WS<sub>2</sub> monolayer](https://platform.mat3ra.com/mat3ra/materials/5JcsfbBPKFWjxGXkX)
+- [MoS<sub>2</sub> monolayer](https://platform.mat3ra.com/mat3ra/materials/Cyr7Y6sefZsmZo6bH)
 
 !!!warning "Material order"
     The VBO workflow assumes the interface structure corresponds to the first material. The interface structure must be loaded first.
@@ -54,7 +54,7 @@ The initial interface structure was taken from [materialsproject.org](https://ma
 
 The [workflow]({{ reference_url }}/workflows/overview/) for calculating the VBO can be [imported]({{ interface_url }}/workflows/actions/copy-bank/) from the [Workflows Bank]({{ reference_url }}/workflows/bank/) into the account-owned [collection]({{ reference_url }}/accounts/collections/). The workflow can then be [selected]({{ interface_url }}/jobs-designer/actions-header-menu/select-workflow/) and added to the [job being created]({{ interface_url }}/jobs-designer/workflow-tab/).
 
-A [representation of this workflow](https://github.com/Exabyte-io/wode.js/blob/2022.11.16-0/assets/workflows/espresso/valence_band_offset.yml) is also available in the Mat3ra workflow definitions repository ([wode.js](https://github.com/Exabyte-io/wode.js)).
+A [representation of this workflow](https://github.com/mat3ra/wode.js/blob/2022.11.16-0/assets/workflows/espresso/valence_band_offset.yml) is also available in the Mat3ra workflow definitions repository ([wode.js](https://github.com/mat3ra/wode.js)).
 
 [![Valence Band Offset Workflow](../../../images/tutorials/valence-band-offset-workflow.png "Valence Band Offset Workflow")](../../../images/tutorials/valence-band-offset-workflow.png)
 

--- a/lang/en/docs/tutorials/dft/optical/epsilon-optimal-basis.md
+++ b/lang/en/docs/tutorials/dft/optical/epsilon-optimal-basis.md
@@ -2,7 +2,7 @@
 
 This tutorial demonstrates how to calculate the dielectric function of silicon using the SIMPLE.x program in Quantum ESPRESSO, which employs optimal basis functions for optical property calculations. The detailed physics behind this method is described in: [SIMPLE code: Optical properties with optimal basis functions, Prandini, G., Galante, M., Marzari, N., & Umari, P., Computer Physics Communications, **240**, 106 (2019)](https://doi.org/10.1016/j.cpc.2019.02.016).
 
-The workflow below replicates [example 5 from the Quantum ESPRESSO GWW directory](https://gitlab.com/QEF/q-e/-/tree/qe-7.3/GWW/examples/). Input and reference output files are also available in the [CLI-job-examples repository](https://github.com/Exabyte-io/cli-job-examples/tree/main/espresso/simple.x).
+The workflow below replicates [example 5 from the Quantum ESPRESSO GWW directory](https://gitlab.com/QEF/q-e/-/tree/qe-7.3/GWW/examples/). Input and reference output files are also available in the [CLI-job-examples repository](https://github.com/mat3ra/cli-job-examples/tree/main/espresso/simple.x).
 
 
 ## 1. Create the workflow

--- a/lang/en/docs/tutorials/jobs-cli/qe-gpu.md
+++ b/lang/en/docs/tutorials/jobs-cli/qe-gpu.md
@@ -19,10 +19,10 @@ Connect to the login node via [SSH client]({{ cli_url }}/remote-connection/ssh/)
 
 ## 2. Clone the example repository
 
-The example job is available in the git repository [exabyte-io/cli-job-examples](https://github.com/exabyte-io/cli-job-examples). Clone the repository to the working directory:
+The example job is available in the git repository [mat3ra/cli-job-examples](https://github.com/mat3ra/cli-job-examples). Clone the repository to the working directory:
 
 ```bash
-git clone https://github.com/exabyte-io/cli-job-examples
+git clone https://github.com/mat3ra/cli-job-examples
 cd cli-job-examples
 git lfs pull
 cd espresso/gpu

--- a/lang/en/docs/tutorials/materials/specific/defect-point-interstitial-tin-oxide.md
+++ b/lang/en/docs/tutorials/materials/specific/defect-point-interstitial-tin-oxide.md
@@ -28,7 +28,7 @@ This tutorial demonstrates how to create an oxygen interstitial defect in tin mo
     Physical Review B 74, 195128 (2006)
     [DOI: 10.1103/PhysRevB.74.195128](https://doi.org/10.1103/PhysRevB.74.195128){:target='_blank'}. [@Togo2006; @Wang2014; @Na-Phattalung2006]
 
-We will recreate the O-interstitial defect structure shown in Fig. 4 a) using [Voronoi](https://github.com/Exabyte-io/made/blob/9e13b350eaaa5d49c81a3b30f76c165480825d72/src/py/mat3ra/made/tools/build/defect/builders.py#L125) placement method.
+We will recreate the O-interstitial defect structure shown in Fig. 4 a) using [Voronoi](https://github.com/mat3ra/made/blob/9e13b350eaaa5d49c81a3b30f76c165480825d72/src/py/mat3ra/made/tools/build/defect/builders.py#L125) placement method.
 
 ![SnO O-interstitial](../../../images/tutorials/materials/defects/defect_point_interstitial_tin_oxide/0-figure-from-manuscript.webp "O-interstitial defect in SnO")
 

--- a/lang/en/docs/tutorials/materials/specific/defect-point-pair-gallium-nitride.md
+++ b/lang/en/docs/tutorials/materials/specific/defect-point-pair-gallium-nitride.md
@@ -78,7 +78,7 @@ Find `create_point_defect_pair.ipynb` in the list of notebooks and click/double-
 
 ### 4.3. Open and modify the notebook
 
-Next, edit `create_point_defect_pair.ipynb` notebook to modify the parameters by adding a list of [defect configuration objects](https://github.com/Exabyte-io/made/blob/3d938b4d91a31323dca7a02acb12b646dbb26634/src/py/mat3ra/made/tools/build/defect/configuration.py#L257) containing the approximate coordinates of the atoms to replace.
+Next, edit `create_point_defect_pair.ipynb` notebook to modify the parameters by adding a list of [defect configuration objects](https://github.com/mat3ra/made/blob/3d938b4d91a31323dca7a02acb12b646dbb26634/src/py/mat3ra/made/tools/build/defect/configuration.py#L257) containing the approximate coordinates of the atoms to replace.
 
 Copy the below content and edit the "1.1. Set up defect parameters" cell in the notebook as follows:
 

--- a/lang/en/docs/tutorials/materials/specific/defect-point-substitution-graphene.md
+++ b/lang/en/docs/tutorials/materials/specific/defect-point-substitution-graphene.md
@@ -69,7 +69,7 @@ Find `create_point_defect.ipynb` in the list of notebooks and click/double-click
 
 ### 4.3. Open and modify the notebook
 
-Next, edit `create_point_defect.ipynb` notebook to modify the parameters by adding a list of [defect configuration objects](https://github.com/Exabyte-io/made/blob/3d938b4d91a31323dca7a02acb12b646dbb26634/src/py/mat3ra/made/tools/build/defect/configuration.py#L32) containing the approximate coordinates of the atoms to replace.
+Next, edit `create_point_defect.ipynb` notebook to modify the parameters by adding a list of [defect configuration objects](https://github.com/mat3ra/made/blob/3d938b4d91a31323dca7a02acb12b646dbb26634/src/py/mat3ra/made/tools/build/defect/configuration.py#L32) containing the approximate coordinates of the atoms to replace.
 
 Copy the below content and edit the "1.1. Set up defect parameters" cell in the notebook as follows:
 

--- a/lang/en/docs/tutorials/materials/specific/defect-surface-island-titanium-nitride.md
+++ b/lang/en/docs/tutorials/materials/specific/defect-surface-island-titanium-nitride.md
@@ -119,7 +119,7 @@ Find `create_island_defect.ipynb` in the list of notebooks and double-click open
 
 ### 4.2. Modify the notebook
 
-Next, edit `create_island_defect.ipynb` notebook to modify the parameters by adding a list of [defect configuration objects](https://github.com/Exabyte-io/made/blob/3d938b4d91a31323dca7a02acb12b646dbb26634/src/py/mat3ra/made/tools/build/defect/configuration.py#L191) containing the cartesian coordinates of the island vertices.
+Next, edit `create_island_defect.ipynb` notebook to modify the parameters by adding a list of [defect configuration objects](https://github.com/mat3ra/made/blob/3d938b4d91a31323dca7a02acb12b646dbb26634/src/py/mat3ra/made/tools/build/defect/configuration.py#L191) containing the cartesian coordinates of the island vertices.
 
 With the same TiN material selected in the materials input and coordinates for the island vertices from the previous step, the user can create the island on the surface.
 

--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -1,5 +1,5 @@
-repo_name: 'exabyte-io/documentation'
-repo_url: 'https://github.com/exabyte-io/documentation'
+repo_name: 'mat3ra/documentation'
+repo_url: 'https://github.com/mat3ra/documentation'
 edit_uri: 'edit/main/lang/en/docs/'
 
 extra_css:
@@ -31,7 +31,7 @@ extra:
         - /extra/js/preload.js
     social:
         - icon: fontawesome/brands/github
-          link: https://github.com/exabyte-io
+          link: https://github.com/mat3ra
         - icon: fontawesome/brands/youtube
           link: https://www.youtube.com/c/Mat3ra/videos
         - icon: fontawesome/brands/linkedin


### PR DESCRIPTION
## Summary

Updates all references to the GitHub organization name from `Exabyte-io`/`exabyte-io` to `mat3ra` following the organization rename on GitHub.

### Changes
- Replace all `github.com/Exabyte-io/` and `github.com/exabyte-io/` URLs with `github.com/mat3ra/`
- Rename `exabyte-api-client` repo reference → `api-client`
- Rename `exabyte-api-examples` repo reference → `api-examples`
- Update `mkdocs-base.yml` `repo_name` and `repo_url`
- Update CI workflow action references (`.github/workflows/`)
- Update `.gitmodules` submodule URL
- Update footnote link text to use Mat3ra branding
- Update example JSON data organization slugs and cluster directory paths
- Update GHCR container registry paths (`ghcr.io/exabyte-io/` → `ghcr.io/mat3ra/`)

### Verification
- All 8 documentation sites built successfully
- Link checker scanned 327,027 internal links — no broken links found